### PR TITLE
fixed unicode encoding error; broke mp4 conversion

### DIFF
--- a/echo360/downloader.py
+++ b/echo360/downloader.py
@@ -1,7 +1,11 @@
+from __future__ import unicode_literals
 import dateutil.parser
 import os
 import sys
 import logging
+
+reload(sys)
+sys.setdefaultencoding('utf8')
 
 from echo360.hls_downloader import Downloader
 from echo360.exceptions import EchoLoginError


### PR DESCRIPTION
See #7 

Makes script work with European echo360 portals that use special characters.

Don't have time to fix mp4 problem right, guess it's minor...