### PR TITLE
Add ability to download both video feeds for each lecture

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "python.pythonPath": "/usr/bin/python3"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.pythonPath": "/usr/bin/python3"
+}

--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ optional arguments:
                         Path to the desired output directory. The output
                         directory must exist. Otherwise the current directory
                         is used.
-  --after-date AFTER_DATE(YYYY-MM-DD), -a AFTER_DATE(YYYY-MM-DD)
+  --after-date AFTER_DATE(YYYY-MM-DD)
                         Only download lectures newer than AFTER_DATE
                         (inclusive). Note: this may be combined with --before-
                         date.
-  --before-date BEFORE_DATE(YYYY-MM-DD), -b BEFORE_DATE(YYYY-MM-DD)
+  --before-date BEFORE_DATE(YYYY-MM-DD)
                         Only download lectures older than BEFORE_DATE
                         (inclusive). Note: this may be combined with --after-
                         date
@@ -121,6 +121,12 @@ optional arguments:
                         logging into your institution's SSO; i.e. it will
                         disable the automatic redirection which is the default
                         behavior.
+  --alternative_feeds, -a
+                        Download first two video feeds. Since some university 
+                        have multiple video feeds, with this option on the 
+                        downloader will also try to download the second video, 
+                        which could be the alternative feed. Might only work 
+                        on some 'echo360.org' hosts.
   --debug               Enable extensive logging.
 ```
 # Examples
@@ -279,6 +285,10 @@ You are in luck! It is now possible to pick a subset of videos to download from 
 ...and it shall presents an interactive screen for you to pick each individual video(s) that you want to download, like the screenshot as shown below.
 
 <img src="/docs/images/pick_individual_videos_screenshot.png" width="650" height="auto" >
+
+### My lecture has two video feeds, how can I download both of them?
+
+You can add argument `--alternative_feeds` or simply `-a` to download both video feeds.
 
 ### Technical details
 

--- a/echo360/course.py
+++ b/echo360/course.py
@@ -13,13 +13,13 @@ _LOGGER = logging.getLogger(__name__)
 
 class EchoCourse(object):
 
-    def __init__(self, uuid, hostname=None, two_feeds=False):
+    def __init__(self, uuid, hostname=None, alternative_feeds=False):
         self._course_id = None
         self._course_name = None
         self._uuid = uuid
         self._videos = None
         self._driver = None
-        self._two_feeds = two_feeds
+        self._alternative_feeds = alternative_feeds
         if hostname is None:
             self._hostname = "https://view.streaming.sydney.edu.au:8443"
         else:
@@ -128,7 +128,7 @@ class EchoCloudCourse(EchoCourse):
             try:
                 course_data_json = self._get_course_data()
                 videos_json = course_data_json["data"]
-                self._videos = EchoCloudVideos(videos_json, self._driver, self.hostname, self._two_feeds)
+                self._videos = EchoCloudVideos(videos_json, self._driver, self.hostname, self._alternative_feeds)
             # except KeyError as e:
             #     print("Unable to parse course videos from JSON (course_data)")
             #     raise e

--- a/echo360/course.py
+++ b/echo360/course.py
@@ -13,12 +13,13 @@ _LOGGER = logging.getLogger(__name__)
 
 class EchoCourse(object):
 
-    def __init__(self, uuid, hostname=None):
+    def __init__(self, uuid, hostname=None, two_feeds=False):
         self._course_id = None
         self._course_name = None
         self._uuid = uuid
         self._videos = None
         self._driver = None
+        self._two_feeds = two_feeds
         if hostname is None:
             self._hostname = "https://view.streaming.sydney.edu.au:8443"
         else:
@@ -127,7 +128,7 @@ class EchoCloudCourse(EchoCourse):
             try:
                 course_data_json = self._get_course_data()
                 videos_json = course_data_json["data"]
-                self._videos = EchoCloudVideos(videos_json, self._driver, self.hostname)
+                self._videos = EchoCloudVideos(videos_json, self._driver, self.hostname, self._two_feeds)
             # except KeyError as e:
             #     print("Unable to parse course videos from JSON (course_data)")
             #     raise e

--- a/echo360/downloader.py
+++ b/echo360/downloader.py
@@ -250,6 +250,7 @@ class EchoDownloader(object):
 
     def _get_filename(self, course, date, title):
         if course:
+            # add [:150] to avoid filename too long exception
             filename = "{} - {} - {}".format(course, date, title[:150])
         else:
             filename = "{} - {}".format(date, title[:150])

--- a/echo360/downloader.py
+++ b/echo360/downloader.py
@@ -250,9 +250,9 @@ class EchoDownloader(object):
 
     def _get_filename(self, course, date, title):
         if course:
-            filename = "{} - {} - {}".format(course, date, title)
+            filename = "{} - {} - {}".format(course, date, title[:150])
         else:
-            filename = "{} - {}".format(date, title)
+            filename = "{} - {}".format(date, title[:150])
         # replace invalid character for files
         return self.regex_replace_invalid.sub('_', filename)
 

--- a/echo360/main.py
+++ b/echo360/main.py
@@ -138,6 +138,17 @@ def handle_args():
                               redirection which is the default behavior.",
     )
     parser.add_argument(
+        "--two-feeds",
+        "-t",
+        action="store_true",
+        default=False,
+        dest="two_feeds",
+        help="Download first two video feeds. Since some university have multiple \
+                video feeds, with this option on the downloader will also try to download \
+                the second video, which could be the alternative feed. Might only work on \
+                some 'echo360.org' hosts.",
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         default=False,
@@ -206,6 +217,7 @@ def handle_args():
         args["interactive"],
         args["enable_degbug"],
         args["manual"],
+        args["two_feeds"],
     )
 
 
@@ -224,6 +236,7 @@ def main():
         interactive_mode,
         enable_degbug,
         manual,
+        two_feeds
     ) = handle_args()
 
     setup_logging(enable_degbug)
@@ -293,7 +306,7 @@ def main():
         course_uuid = re.search(
             "[^/]([0-9a-zA-Z]+[-])+[0-9a-zA-Z]+", course_url
         ).group()  # retrieve the last part of the URL
-        course = EchoCloudCourse(course_uuid, course_hostname)
+        course = EchoCloudCourse(course_uuid, course_hostname, two_feeds)
     else:
         # import it here for monkey patching gevent, to fix the followings:
         # MonkeyPatchWarning: Monkey-patching ssl after ssl has already been

--- a/echo360/main.py
+++ b/echo360/main.py
@@ -54,7 +54,6 @@ def handle_args():
     )
     parser.add_argument(
         "--after-date",
-        "-a",
         dest="after_date",
         help="Only download lectures newer than AFTER_DATE \
                              (inclusive). Note: this may be combined with \
@@ -63,7 +62,6 @@ def handle_args():
     )
     parser.add_argument(
         "--before-date",
-        "-b",
         dest="before_date",
         help="Only download lectures older than BEFORE_DATE \
                               (inclusive). Note: this may be combined with \
@@ -138,11 +136,11 @@ def handle_args():
                               redirection which is the default behavior.",
     )
     parser.add_argument(
-        "--two-feeds",
-        "-t",
+        "--alternative_feeds",
+        "-a",
         action="store_true",
         default=False,
-        dest="two_feeds",
+        dest="alternative_feeds",
         help="Download first two video feeds. Since some university have multiple \
                 video feeds, with this option on the downloader will also try to download \
                 the second video, which could be the alternative feed. Might only work on \
@@ -217,7 +215,7 @@ def handle_args():
         args["interactive"],
         args["enable_degbug"],
         args["manual"],
-        args["two_feeds"],
+        args["alternative_feeds"],
     )
 
 
@@ -236,7 +234,7 @@ def main():
         interactive_mode,
         enable_degbug,
         manual,
-        two_feeds
+        alternative_feeds
     ) = handle_args()
 
     setup_logging(enable_degbug)
@@ -306,7 +304,7 @@ def main():
         course_uuid = re.search(
             "[^/]([0-9a-zA-Z]+[-])+[0-9a-zA-Z]+", course_url
         ).group()  # retrieve the last part of the URL
-        course = EchoCloudCourse(course_uuid, course_hostname, two_feeds)
+        course = EchoCloudCourse(course_uuid, course_hostname, alternative_feeds)
     else:
         # import it here for monkey patching gevent, to fix the followings:
         # MonkeyPatchWarning: Monkey-patching ssl after ssl has already been

--- a/echo360/main.py
+++ b/echo360/main.py
@@ -397,7 +397,7 @@ def setup_logging(enable_degbug=False):
     )
     # define a Handler which writes INFO messages or higher to the sys.stderr
     console = logging.StreamHandler()
-    console.setLevel(logging.INFO)
+    console.setLevel(logging_level)
     console.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
     logging.getLogger("").addHandler(console)  # add handler to the root logger
 

--- a/echo360/videos.py
+++ b/echo360/videos.py
@@ -178,7 +178,7 @@ class EchoVideo(object):
 
 
 class EchoCloudVideos(EchoVideos):
-    def __init__(self, videos_json, driver, hostname):
+    def __init__(self, videos_json, driver, hostname, two_feeds):
         assert (videos_json is not None)
         self._driver = driver
         self._videos = []
@@ -186,7 +186,7 @@ class EchoCloudVideos(EchoVideos):
         update_course_retrieval_progress(0, total_videos_num)
 
         for i, video_json in enumerate(videos_json):
-            self._videos.append(EchoCloudVideo(video_json, self._driver, hostname))
+            self._videos.append(EchoCloudVideo(video_json, self._driver, hostname, two_feeds))
             update_course_retrieval_progress(i + 1, total_videos_num)
 
         self._videos.sort(key=operator.attrgetter("date"))
@@ -202,12 +202,13 @@ class EchoCloudVideo(EchoVideo):
     def video_url(self):
         return "{}/lesson/{}/classroom".format(self.hostname, self.video_id)
 
-    def __init__(self, video_json, driver, hostname):
+    def __init__(self, video_json, driver, hostname, two_feeds):
         self.hostname = hostname
         self._driver = driver
         self.video_json = video_json
         self.is_multipart_video = False
         self.sub_videos = [self]
+        self.download_two_feeds = two_feeds
         if 'lessons' in video_json:
             # IS a multi-part lesson.
             self.sub_videos = [EchoCloudSubVideo(sub_video_json, driver, hostname,
@@ -246,14 +247,20 @@ class EchoCloudVideo(EchoVideo):
         for cookie in self._driver.get_cookies():
             session.cookies.set(cookie["name"], cookie["value"])
 
-        urls = self.url
-        if(not isinstance(urls, list)):
+        if(isinstance(self.url, list)):
+            urls = self.url
+        else:
             urls = [self.url]
+
+        if(not self.download_two_feeds):
+            # download_two_feeds defaults to False, slice to include only the first one
+            urls = urls[:1]
 
         final_result = True
         for counter, single_url in enumerate(urls):
-            print('- Downloading Video {}...'.format(counter + 1))
-            new_filename = filename + str(counter + 1)
+            if(self.download_two_feeds):
+                print('- Downloading video feed {}...'.format(counter + 1))
+            new_filename = (filename + str(counter + 1)) if self.download_two_feeds else filename
             result = self.download_single(session, single_url, output_dir, new_filename, pool_size)
             final_result = final_result and result
         
@@ -270,7 +277,7 @@ class EchoCloudVideo(EchoVideo):
             lines = [n for n in r.content.decode().split('\n')]
             m3u8_video = None
             m3u8_audio = None
-            print(lines)
+
             for i in range(1, len(lines)):
                 if lines[i].strip() == "":
                     continue
@@ -375,6 +382,8 @@ class EchoCloudVideo(EchoVideo):
             # in many cases, there would be urls in the format of http://xxx.{hd1,hd2,sd1,sd2}
             # I'm not sure what does the 1 and 2 in hd1,hd2 stands for, but hd and sd should means
             # high or low definition.
+            # Some university uses hd1 and hd2 for their alternative feeds, use flag `-t` 
+            # to download both feeds.
             # Let's prioritise hd over sd, and 1 over 2 (the latter is arbitary)
             # which happens to be the natual order of letter anyway, so we can simply use sorted.
             return sorted(urls)[:2]
@@ -456,13 +465,15 @@ class EchoCloudVideo(EchoVideo):
         # different quality?? We will set it to always prefer higher number.
         # Since (from my experiment) the prefixes are always the same, we will
         # just use text sorting to get the higher number.
+        # Some university have two different video feeds, use flag `-t` to
+        # download both feeds.
         m3u8urls = reversed(m3u8urls)
         first_url = next(m3u8urls)
         try:
             second_url = next(m3u8urls)
             return [first_url, second_url]
         except Exception as e:
-            return first_url
+            return [first_url]
 
     def _extract_date(self, video_json):
         if self.is_multipart_video:

--- a/echo360/videos.py
+++ b/echo360/videos.py
@@ -178,7 +178,7 @@ class EchoVideo(object):
 
 
 class EchoCloudVideos(EchoVideos):
-    def __init__(self, videos_json, driver, hostname, two_feeds):
+    def __init__(self, videos_json, driver, hostname, alternative_feeds):
         assert (videos_json is not None)
         self._driver = driver
         self._videos = []
@@ -186,7 +186,7 @@ class EchoCloudVideos(EchoVideos):
         update_course_retrieval_progress(0, total_videos_num)
 
         for i, video_json in enumerate(videos_json):
-            self._videos.append(EchoCloudVideo(video_json, self._driver, hostname, two_feeds))
+            self._videos.append(EchoCloudVideo(video_json, self._driver, hostname, alternative_feeds))
             update_course_retrieval_progress(i + 1, total_videos_num)
 
         self._videos.sort(key=operator.attrgetter("date"))
@@ -202,13 +202,13 @@ class EchoCloudVideo(EchoVideo):
     def video_url(self):
         return "{}/lesson/{}/classroom".format(self.hostname, self.video_id)
 
-    def __init__(self, video_json, driver, hostname, two_feeds):
+    def __init__(self, video_json, driver, hostname, alternative_feeds):
         self.hostname = hostname
         self._driver = driver
         self.video_json = video_json
         self.is_multipart_video = False
         self.sub_videos = [self]
-        self.download_two_feeds = two_feeds
+        self.download_alternative_feeds = alternative_feeds
         if 'lessons' in video_json:
             # IS a multi-part lesson.
             self.sub_videos = [EchoCloudSubVideo(sub_video_json, driver, hostname,
@@ -247,20 +247,19 @@ class EchoCloudVideo(EchoVideo):
         for cookie in self._driver.get_cookies():
             session.cookies.set(cookie["name"], cookie["value"])
 
-        if(isinstance(self.url, list)):
-            urls = self.url
-        else:
-            urls = [self.url]
+        urls = self.url
+        if not isinstance(urls, list):
+            urls = [urls]
 
-        if(not self.download_two_feeds):
-            # download_two_feeds defaults to False, slice to include only the first one
+        if(not self.download_alternative_feeds):
+            # download_alternative_feeds defaults to False, slice to include only the first one
             urls = urls[:1]
 
         final_result = True
         for counter, single_url in enumerate(urls):
-            if(self.download_two_feeds):
+            if(self.download_alternative_feeds):
                 print('- Downloading video feed {}...'.format(counter + 1))
-            new_filename = (filename + str(counter + 1)) if self.download_two_feeds else filename
+            new_filename = (filename + str(counter + 1)) if self.download_alternative_feeds else filename
             result = self.download_single(session, single_url, output_dir, new_filename, pool_size)
             final_result = final_result and result
         
@@ -382,7 +381,7 @@ class EchoCloudVideo(EchoVideo):
             # in many cases, there would be urls in the format of http://xxx.{hd1,hd2,sd1,sd2}
             # I'm not sure what does the 1 and 2 in hd1,hd2 stands for, but hd and sd should means
             # high or low definition.
-            # Some university uses hd1 and hd2 for their alternative feeds, use flag `-t` 
+            # Some university uses hd1 and hd2 for their alternative feeds, use flag `-a` 
             # to download both feeds.
             # Let's prioritise hd over sd, and 1 over 2 (the latter is arbitary)
             # which happens to be the natual order of letter anyway, so we can simply use sorted.
@@ -465,15 +464,10 @@ class EchoCloudVideo(EchoVideo):
         # different quality?? We will set it to always prefer higher number.
         # Since (from my experiment) the prefixes are always the same, we will
         # just use text sorting to get the higher number.
-        # Some university have two different video feeds, use flag `-t` to
+        # Some university have two different video feeds, use flag `-a` to
         # download both feeds.
-        m3u8urls = reversed(m3u8urls)
-        first_url = next(m3u8urls)
-        try:
-            second_url = next(m3u8urls)
-            return [first_url, second_url]
-        except Exception as e:
-            return [first_url]
+        m3u8urls = list(reversed(m3u8urls))
+        return m3u8urls[:2]
 
     def _extract_date(self, video_json):
         if self.is_multipart_video:


### PR DESCRIPTION
Should fix #28.

The original methods for getting the video links only returns the first video among the array of videos for each lecture. However, most universities have two video feeds for their echo360 lecture casts (one for the screen and one for the camera).

For example, our university uses`echo360.org` platform, the URL array crawled by the program already contains all the feeds of the lecture, usually named `hd1`, `hd2` or `sd1`, `sd2`, sorted alphabetically, the original methods will only choose `hd1` to download. 

With this PR it will try to download the first two feeds, it might only work with `echo360.org` platform and download methods except `from_json_mp4`. Currently, this behaviour is on by default, maybe we could add another argument in main to make this optional :)

### Minor bug fixes
-  Fix `--debug` flag doesn't work
-  Fix 'file name too long' exception