### PR TITLE
Make `cmd_exists()` return a the result.

### DIFF
--- a/echo360/main.py
+++ b/echo360/main.py
@@ -268,7 +268,7 @@ def main():
         setup_credential = True
 
     def cmd_exists(x):
-        any(
+        return any(
             os.access(os.path.join(path, x), os.X_OK)
             for path in os.environ["PATH"].split(os.pathsep)
         )


### PR DESCRIPTION
It is implicitly none otherwise so it would download the driver even if installed locally.