### PR TITLE
Bump selenium version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil>=2.2
-selenium>=2.44.0,<4.1.4
+selenium>=2.44.0
 ffmpy>=0.2.2
 requests>=2.8.14
 gevent>=1.2.2


### PR DESCRIPTION
This PR lifts the upper version limit for `selenium`, adding support for modern versions of Chrome and Chrome Drivers. This is possible via changes in https://github.com/soraxas/echo360/commit/d2de7875cfc607bb5d4c44c02f63a4a765a04e83. 

Closes #78 