### PR TITLE
Support skipping downloaded videos

### DIFF
--- a/echo360/videos.py
+++ b/echo360/videos.py
@@ -296,6 +296,10 @@ class EchoCloudVideo(EchoVideo):
         return final_result
 
     def download_single(self, session, single_url, output_dir, filename, pool_size):
+        if os.path.exists(os.path.join(output_dir, filename + ".mp4")):
+            print(f" > Skip download video")
+            print("-" * 60)
+            return True
         if single_url.endswith(".m3u8"):
             r = session.get(single_url)
             if not r.ok:


### PR DESCRIPTION
Sometimes when the video amount is huge, the downloader will exit due to panic error, like http issue timeout and so on. 
This PR avoids re-download the existed video files, making the downloading incremental :)
<img width="675" alt="image" src="https://github.com/user-attachments/assets/be2f1c41-98d2-4587-8639-af2428131383" />
