### PR TITLE
download subtitles and presentations and handle groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ default_out_path/
 _browser_user_data_dir/
 
 .vscode/
+_browser_persistent_session/

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ target/
 bin/
 default_out_path/
 _browser_user_data_dir/
+
+.vscode/

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ optional arguments:
                         video, which could be the alternative feed. Might
                         only work on some 'echo360.org' hosts.
   --subtitles, -s       Download VTT subtitles for each video feed.
+  --dump-json           Download JSON representation of course to output directory.
   --debug               Enable extensive logging.
   --auto                Only effective for 'echo360.org' host. When set, this
                         script will attempts to automatically redirects after

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See it in action:
     <img width="700" height="auto" src="docs/images/demo.gif" alt="echo360 demo" />
 </p>
 
-**NEWS:** It now works with `echo360.org` platform as well. Special thanks to [*@cloudrac3r*](https://github.com/cloudrac3r) and *Emma* for their kind offering of providing sources and helped debugging it. Read [FAQ](#echo360-cloud) for details.
+**NEWS:** It now works with `echo360.org` platform as well. Special thanks to [_@cloudrac3r_](https://github.com/cloudrac3r) and _Emma_ for their kind offering of providing sources and helped debugging it. Read [FAQ](#echo360-cloud) for details.
 
 # Getting Started
 
@@ -44,7 +44,7 @@ echo360-downloader COURSE_URL  # where COURSE_URL is your course url
 
 ### Optional
 
--   ffmpeg (for transcoding ts file to mp4 file) See [here (windows)](https://www.easytechguides.com/install-ffmpeg/) or [here](https://github.com/adaptlearning/adapt_authoring/wiki/Installing-FFmpeg) for a brief instructions of installing it in different OS.
+- ffmpeg (for transcoding ts file to mp4 file) See [here (windows)](https://www.easytechguides.com/install-ffmpeg/) or [here](https://github.com/adaptlearning/adapt_authoring/wiki/Installing-FFmpeg) for a brief instructions of installing it in different OS.
 
 ## Manual
 
@@ -62,9 +62,9 @@ python echo360.py
 
 ### Operating System
 
--   Linux
--   OS X
--   Windows
+- Linux
+- OS X
+- Windows
 
 # Usage
 
@@ -78,6 +78,7 @@ python echo360.py
 ```
 
 ### Script args
+
 ```
 >>> usage: echo360.py [-h] [--output OUTPUT_PATH]
                   [--after-date AFTER_DATEYYYY-MM-DD)]
@@ -135,6 +136,7 @@ optional arguments:
                         downloader will also try to download the second
                         video, which could be the alternative feed. Might
                         only work on some 'echo360.org' hosts.
+  --subtitles, -s       Download VTT subtitles for each video feed.
   --debug               Enable extensive logging.
   --auto                Only effective for 'echo360.org' host. When set, this
                         script will attempts to automatically redirects after
@@ -145,6 +147,7 @@ optional arguments:
                         default behaviour and exists only for backward
                         compatibility reason.
 ```
+
 # Examples
 
 ```shell
@@ -208,11 +211,15 @@ This is first built for the echo system in the University of Sydney, and then va
 ```shell
 https://$(hostname)/ess/portal/section/$(UUID)
 ```
+
 or
+
 ```shell
 https://echo360.org[.xx]/
 ```
+
 or with a dot net variant
+
 ```shell
 https://echo360.net[.xx]/
 ```
@@ -252,34 +259,38 @@ Echo360 cloud refers to websites in the format of `https://echo360.org[.xx]`. Th
 This method requires you to setup SSO credentials, therefore, it needs to open up a browser for you to setup your own university's SSO credentials.
 
 To download videos, run:
+
 ```shell
 ./run.sh https://echo360.<org|net>[.xx]/section/$(UUID)/home
 ```
-where `[.xx]` is an optional country flag specific to your echo360 platform and `$(UUID)` is the unique identifier for your course. This should the url that you can retrieve from your course's *main page* like the following.
+
+where `[.xx]` is an optional country flag specific to your echo360 platform and `$(UUID)` is the unique identifier for your course. This should the url that you can retrieve from your course's _main page_ like the following.
 
 <img height="auto" src="docs/images/echo360cloud_course-page.png" alt="echo360 cloud course main page" />
 
 Note that this implies `setup-credential` option and will use chrome-webdriver by default. If you don't have chrome or prefer to use firefox, run it with the ` --firefox` flag like so:
+
 ```shell
 ./run.sh https://echo360.<org|net>[.xx]/section/$(UUID)/home --firefox
 ```
 
 After running the command, it will opens up a browser instance, most likely with a login page. You should then login with your student's credentials like what you would normally do. After you have successfully logged in, the module should automatically redirects you and continues. If the script hangs (e.g. failed to recognises that you have logged in), feel free to let me know.
 
-
 ### I'm not sure of how to run it?
 
 First, you'd need to install [Python](https://www.python.org/downloads/) in your system. Then, you can follow the youtube tutorial videos to get an idea of how to use the module.
 
 - For [Windows users](https://www.youtube.com/watch?v=Lv1wtjnCcwI) (and showcased how to retrieve actual echo360 course url)
-[![](docs/images/youtube_win_tutorial.jpg)](https://www.youtube.com/watch?v=Lv1wtjnCcwI)
+  [![](docs/images/youtube_win_tutorial.jpg)](https://www.youtube.com/watch?v=Lv1wtjnCcwI)
 
 ### My credentials does not work?
 
 You can setup any credentials need with manually logging into websites, by running the script with:
+
 ```sh
 ./run.sh ECHO360_URL --setup-credential
 ```
+
 This will open up a chrome instance that allows you to log into your website as you normally do. Afterwards, simply type 'continue' into your shell and press enter to continue to proceeds with the rest of the script.
 
 ### My credentials does not work (echo360.org)?
@@ -287,21 +298,27 @@ This will open up a chrome instance that allows you to log into your website as 
 For echo360.org, the default behaviour is it will always require you to setup-credentials, and the module will automatically detect login token and proceed the download process. For some institutions, this seems to be not sufficient (#29).
 
 You can disable such behaviour with
+
 ```sh
 ./run.sh ECHO360_ORG_URL --manual
 ```
+
 for manual setup; and once you had logged in, type
+
 ```sh
 continue
 ```
+
 in your terminal to continue.
 
 ### How do I download only individual video(s)?
 
 You are in luck! It is now possible to pick a subset of videos to download from (instead of needing to download everything like before). Just pass the interactive argument like this:
+
 ```sh
 ./run.sh ECHO360_URL --interactive  # or ./run.sh ECHO360_URL -i
 ```
+
 ...and it shall presents an interactive screen for you to pick each individual video(s) that you want to download, like the screenshot as shown below.
 
 <img src="/docs/images/pick_individual_videos_screenshot.png" width="650" height="auto" >

--- a/echo360/course.py
+++ b/echo360/course.py
@@ -12,13 +12,14 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class EchoCourse(object):
-    def __init__(self, uuid, hostname=None, alternative_feeds=False):
+    def __init__(self, uuid, hostname=None, alternative_feeds=False, subtitles=False):
         self._course_id = None
         self._course_name = None
         self._uuid = uuid
         self._videos = None
         self._driver = None
         self._alternative_feeds = alternative_feeds
+        self._subtitles = subtitles
         if hostname is None:
             self._hostname = "https://view.streaming.sydney.edu.au:8443"
         else:
@@ -139,7 +140,7 @@ class EchoCloudCourse(EchoCourse):
                 course_data_json = self._get_course_data()
                 videos_json = course_data_json["data"]
                 self._videos = EchoCloudVideos(
-                    videos_json, self._driver, self.hostname, self._alternative_feeds
+                    videos_json, self._driver, self.hostname, self._alternative_feeds, self._subtitles
                 )
             # except KeyError as e:
             #     print("Unable to parse course videos from JSON (course_data)")

--- a/echo360/main.py
+++ b/echo360/main.py
@@ -163,6 +163,14 @@ def handle_args():
                 some 'echo360.org' hosts.",
     )
     parser.add_argument(
+        "--subtitles",
+        "-s",
+        action="store_true",
+        default=False,
+        dest="subtitles",
+        help="Download VTT subtitles for each video feed.",
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         default=False,
@@ -253,6 +261,7 @@ def handle_args():
         args["alternative_feeds"],
         args["echo360cloud"],
         args["persistent_session"],
+        args["subtitles"],
     )
 
 
@@ -274,6 +283,7 @@ def main():
         alternative_feeds,
         usingEcho360Cloud,
         persistent_session,
+        subtitles,
     ) = handle_args()
 
     setup_logging(enable_degbug)
@@ -350,7 +360,7 @@ def main():
         course_uuid = re.search(
             "[^/]([0-9a-zA-Z]+[-])+[0-9a-zA-Z]+", course_url
         ).group()  # retrieve the last part of the URL
-        course = EchoCloudCourse(course_uuid, course_hostname, alternative_feeds)
+        course = EchoCloudCourse(course_uuid, course_hostname, alternative_feeds, subtitles=subtitles)
     else:
         # import it here for monkey patching gevent, to fix the followings:
         # MonkeyPatchWarning: Monkey-patching ssl after ssl has already been
@@ -360,7 +370,7 @@ def main():
         course_uuid = re.search(
             "[^/]+(?=/$|$)", course_url
         ).group()  # retrieve the last part of the URL
-        course = EchoCourse(course_uuid, course_hostname)
+        course = EchoCourse(course_uuid, course_hostname, subtitles=subtitles)
     downloader = EchoDownloader(
         course,
         output_path,

--- a/echo360/main.py
+++ b/echo360/main.py
@@ -171,6 +171,13 @@ def handle_args():
         help="Download VTT subtitles for each video feed.",
     )
     parser.add_argument(
+        "--dump-json",
+        action="store_true",
+        default=False,
+        dest="dump_json",
+        help="Download JSON representation of course to output directory.",
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         default=False,
@@ -262,6 +269,7 @@ def handle_args():
         args["echo360cloud"],
         args["persistent_session"],
         args["subtitles"],
+        args["dump_json"],
     )
 
 
@@ -284,6 +292,7 @@ def main():
         usingEcho360Cloud,
         persistent_session,
         subtitles,
+        dump_json,
     ) = handle_args()
 
     setup_logging(enable_degbug)
@@ -360,7 +369,9 @@ def main():
         course_uuid = re.search(
             "[^/]([0-9a-zA-Z]+[-])+[0-9a-zA-Z]+", course_url
         ).group()  # retrieve the last part of the URL
-        course = EchoCloudCourse(course_uuid, course_hostname, alternative_feeds, subtitles=subtitles)
+        course = EchoCloudCourse(
+            course_uuid, course_hostname, alternative_feeds, subtitles=subtitles
+        )
     else:
         # import it here for monkey patching gevent, to fix the followings:
         # MonkeyPatchWarning: Monkey-patching ssl after ssl has already been
@@ -382,6 +393,7 @@ def main():
         webdriver_to_use=webdriver_to_use,
         interactive_mode=interactive_mode,
         persistent_session=persistent_session,
+        dump_json=dump_json,
     )
 
     _LOGGER.debug(

--- a/echo360/utils.py
+++ b/echo360/utils.py
@@ -6,4 +6,45 @@ def naive_versiontuple(v):
     return tuple(map(int, (v.split("."))))
 
 
+def strip_illegal_path(path: str) -> str:
+    illegal_chars = '<>:"/\\|?*' + "".join(chr(c) for c in range(0, 32))
+    for ch in illegal_chars:
+        path = path.replace(ch, "_")
+
+    reserved_names = {
+        "CON",
+        "PRN",
+        "AUX",
+        "NUL",
+        "COM1",
+        "COM2",
+        "COM3",
+        "COM4",
+        "COM5",
+        "COM6",
+        "COM7",
+        "COM8",
+        "COM9",
+        "LPT1",
+        "LPT2",
+        "LPT3",
+        "LPT4",
+        "LPT5",
+        "LPT6",
+        "LPT7",
+        "LPT8",
+        "LPT9",
+    }
+    name, *ext = path.rsplit(".", 1)
+    if name.upper() in reserved_names:
+        path = f"_{path}"
+
+    path = path.rstrip(" .")
+
+    if path in {".", ".."}:
+        path = "_"
+
+    return path
+
+
 PERSISTENT_SESSION_FOLDER = "_browser_persistent_session"

--- a/echo360/videos.py
+++ b/echo360/videos.py
@@ -16,6 +16,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import StaleElementReferenceException
 
+from .utils import strip_illegal_path
 from .hls_downloader import Downloader
 from .naive_m3u8_parser import NaiveM3U8Parser
 
@@ -187,11 +188,39 @@ class EchoVideo(object):
 
 class EchoCloudVideos(EchoVideos):
     def __init__(
-        self, videos_json, driver, hostname, alternative_feeds, subtitles, skip_video_on_error=True
+        self,
+        course_json,
+        driver,
+        hostname,
+        alternative_feeds,
+        subtitles,
+        skip_video_on_error=True,
     ):
-        assert videos_json is not None
+        assert course_json is not None
         self._driver = driver
         self._videos = []
+
+        # Traverse groups/folders
+        queue = [("", course_json)]
+        videos_json = []
+        # Not sure if the only two types are 'SyllabusLessonType' and 'SyllabusGroupType'.
+        while len(queue) > 0:
+            path, items = queue.pop()
+            for item in items:
+                if type(item) is dict:
+                    if "lesson" in item["type"].lower():
+                        item["path_prefix"] = path
+                        videos_json.append(item)
+                    else:
+                        queue.append(
+                            (
+                                os.path.join(
+                                    path, strip_illegal_path(item["groupInfo"]["name"])
+                                ),
+                                item["lessons"],
+                            )
+                        )
+
         total_videos_num = len(videos_json)
         update_course_retrieval_progress(0, total_videos_num)
 
@@ -222,6 +251,7 @@ class EchoCloudVideo(EchoVideo):
     def __init__(self, video_json, driver, hostname, alternative_feeds, subtitles):
         self.hostname = hostname
         self._driver = driver
+        self._path_prefix = video_json["path_prefix"]
         self.video_json = video_json
         self.is_multipart_video = False
         self.sub_videos = [self]
@@ -261,6 +291,7 @@ class EchoCloudVideo(EchoVideo):
         self._title = video_json["lesson"]["lesson"]["name"]
 
     def download(self, output_dir, filename, pool_size=50):
+        output_dir = os.path.join(output_dir, self._path_prefix)
         print("")
         print("-" * 60)
         print('Downloading "{}"'.format(filename))
@@ -297,6 +328,7 @@ class EchoCloudVideo(EchoVideo):
         return final_result
 
     def download_single(self, session, single_url, output_dir, filename, pool_size):
+        filename = strip_illegal_path(filename)
         if os.path.exists(os.path.join(output_dir, filename + ".mp4")):
             print(" > Skipping downloaded video")
             print("-" * 60)
@@ -335,20 +367,31 @@ class EchoCloudVideo(EchoVideo):
                 # hacky way to get the current url media id
                 # not sure if each feed can have a different media id, so better download it for every feed.
                 try:
-                    media_id = [media["id"] for media in self.video_json['lesson']['medias'] if media["id"] in single_url][0]
+                    media_id = [
+                        media["id"]
+                        for media in self.video_json["lesson"]["medias"]
+                        if media["id"] in single_url
+                    ][0]
                 except IndexError:
                     media_id = None
                 if media_id is not None:
                     print("  > Downloading subtitles:")
                     vtt_url = f"{self.hostname}/api/ui/echoplayer/lessons/{self.video_id}/medias/{media_id}/transcript-file?format=vtt"
-                    cookies = {cookie['name']: cookie['value'] for cookie in self._driver.get_cookies()}
+                    cookies = {
+                        cookie["name"]: cookie["value"]
+                        for cookie in self._driver.get_cookies()
+                    }
                     response = requests.get(vtt_url, cookies=cookies)
                     if response.status_code == 200:
                         head = requests.head(vtt_url, cookies=cookies)
                         if head.status_code == 200:
-                            print(f"Original subtitle name: {head.headers['Content-Disposition']}")
+                            print(
+                                f"Original subtitle name: {head.headers['Content-Disposition']}"
+                            )
                         # Use same filename as mp4 since VLC will automatically use a vtt if the filename matches.
-                        with open(os.path.join(output_dir, f"{filename}.vtt"), "wb") as file:
+                        with open(
+                            os.path.join(output_dir, f"{filename}.vtt"), "wb"
+                        ) as file:
                             file.write(response.content)
                     else:
                         print("No subtitles found.")

--- a/echo360/videos.py
+++ b/echo360/videos.py
@@ -311,6 +311,28 @@ class EchoCloudVideo(EchoVideo):
             # download_alternative_feeds defaults to False, slice to include only the first one
             urls = urls[:1]
 
+        # Download attached media (Example: mediaType: Presentation can contain PDF slides)
+        cookies = {
+            cookie["name"]: cookie["value"] for cookie in self._driver.get_cookies()
+        }
+        for media in self.video_json["lesson"]["medias"]:
+            if media["mediaType"] != "Video":
+                media_filename = media["title"]
+                media_filepath = os.path.join(output_dir, media_filename)
+                media_url = (
+                    f"{self.hostname}/media/download/{media['id']}/{media_filename}"
+                )
+                if os.path.exists(media_filepath):
+                    print(
+                        "> Media {} already downloaded, skipped.".format(media_filename)
+                    )
+                else:
+                    response = requests.get(media_url, cookies=cookies)
+                    if response.status_code == 200:
+                        print("> Downloading media {}...".format(media_filename))
+                        with open(media_filepath, "wb") as file:
+                            file.write(response.content)
+
         final_result = True
         for counter, single_url in enumerate(urls):
             if self.download_alternative_feeds:


### PR DESCRIPTION
Apologies for putting multiple features in one PR, I was modifying it for my courses while scraping them so they were all added spontaneously. 

Happy to split into multiple PRs, though I won't be able to for a while due to IRL stuff.

Features:
- Subtitles are downloaded when the `--subtitles` flag is passed and only downloaded if they do not exist (Resolves #77)
- Lectures containing media files are automatically downloaded. The only one I've seen so far has a mediaType of Presentation and is used to include PDF slides with the lecture video.
- Add --dump-json flag for debugging and for anyone who wants to know what courses were not read etc since the scraping process will mark all videos as read.

Fixes:
- Recursively traverse the course JSON to handle cases where lectures are placed in groups/folders. The group structure will be mirrored in the output directory. Before, any lectures in a group would not be downloaded (which was a problem for some of my courses which made heavy use of this feature)
- Get course name using listing API endpoint which resolves #59 
- Retry on error (can happen when doing too many scrapes simultaneously)
