### PR TITLE
Fix Echo360 cloud course listing and Firefox persistent sessions

### DIFF
--- a/echo360/course.py
+++ b/echo360/course.py
@@ -154,6 +154,10 @@ class EchoCloudCourse(EchoCourse):
         return "{}/section/{}/syllabus".format(self._hostname, self._uuid)
 
     @property
+    def _section_home_url(self):
+        return "{}/section/{}/home".format(self._hostname, self._uuid)
+
+    @property
     def course_id(self):
         if self._course_id is None:
             # self.course_data['data'][0]['lesson']['lesson']['displayName']
@@ -174,14 +178,20 @@ class EchoCloudCourse(EchoCourse):
     @property
     def course_name(self):
         if self._course_name is None:
+            # trigger getting course data (via whichever method actually
+            # worked) so we can look for a course name in it.
+            course_data = getattr(self, "course_data", None) or self._get_course_data()
             # try each available video as some video might be special has contains
             # no information about the course.
-            for v in self.course_data["data"]:
+            for v in course_data.get("data", []):
                 try:
                     self._course_name = v["lesson"]["video"]["published"]["courseName"]
                     break
                 except KeyError:
                     pass
+            # if the JSON API wasn't available, _get_course_data() will
+            # already have set self._course_name as a side effect while
+            # scraping the section page's heading; nothing more to do here.
             if self._course_name is None:
                 # no available course name found...?
                 self._course_name = "[[UNTITLED]]"
@@ -191,31 +201,114 @@ class EchoCloudCourse(EchoCourse):
     def nice_name(self):
         return self.course_name
 
+    _LESSON_ROW_RE = re.compile(
+        r'<div class="class-row([^"]*)"\s+data-test-lessonid="([^"]+)"'
+    )
+    _LESSON_START_TIME_RE = re.compile(
+        r"_(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?)_\d{4}-\d{2}-\d{2}T"
+    )
+    _HEADING_RE = re.compile(r"<h1>\s*(.*?)\s*</h1>", re.DOTALL)
+
     def _get_course_data(self):
+        # Some echo360 cloud/self-hosted instances still serve real JSON
+        # from /section/{id}/syllabus when asked for it. Try that first so
+        # this keeps working wherever it already does.
         try:
-            self.driver.get(self.video_url)
+            course_data = self._fetch_course_data_via_json_api()
+            if course_data.get("data"):
+                self.course_data = course_data
+                return self.course_data
             _LOGGER.debug(
-                "Dumping course page at %s: %s",
-                self.video_url,
-                self._driver.page_source,
+                "JSON syllabus endpoint returned no lessons; falling back to "
+                "scraping the section home page"
             )
-            # Echo360 now content-negotiates on Accept: a plain browser
-            # navigation to this URL gets the React app shell (HTML), but an
-            # XHR/fetch sent with Accept: application/json from within the
-            # already-authenticated page gets the raw JSON, same as the
-            # React app itself does internally. Replaying the selenium
-            # session's cookies into a fresh requests.Session (as this used
-            # to do) no longer works: Echo360 doesn't recognize that
-            # replayed session and redirects it to the login page instead.
-            fetch_script = """
-                var callback = arguments[arguments.length - 1];
-                fetch(arguments[0], {headers: {'Accept': 'application/json'}, credentials: 'same-origin'})
-                  .then(function(r) { return r.text(); })
-                  .then(function(t) { callback(t); })
-                  .catch(function(e) { callback('FETCH_ERROR: ' + e); });
-            """
-            json_str = self.driver.execute_async_script(fetch_script, self.video_url)
-        except ValueError as e:
-            raise Exception("Unable to retrieve JSON (course_data) from url", e)
-        self.course_data = json.loads(json_str)
+        except Exception as e:
+            _LOGGER.debug(
+                "JSON syllabus endpoint unavailable (%s); falling back to "
+                "scraping the section home page",
+                e,
+            )
+        return self._scrape_course_data_from_section_page()
+
+    def _fetch_course_data_via_json_api(self):
+        self.driver.get(self.video_url)
+        _LOGGER.debug(
+            "Dumping course page at %s: %s",
+            self.video_url,
+            self._driver.page_source,
+        )
+        # A plain browser navigation to this URL may get the React app shell
+        # (HTML) back on newer echo360 instances instead of JSON, so ask for
+        # JSON explicitly via an authenticated in-page fetch() - the same
+        # thing the React app itself would do internally when this endpoint
+        # is the one actually backing it.
+        fetch_script = """
+            var callback = arguments[arguments.length - 1];
+            fetch(arguments[0], {headers: {'Accept': 'application/json'}, credentials: 'same-origin'})
+              .then(function(r) { return r.text().then(function(t){ return {status: r.status, body: t}; }); })
+              .then(function(result) { callback(result); })
+              .catch(function(e) { callback({status: -1, body: 'FETCH_ERROR: ' + String(e)}); });
+        """
+        result = self.driver.execute_async_script(fetch_script, self.video_url)
+        if result["status"] != 200:
+            raise Exception(
+                "JSON syllabus endpoint returned status {}: {}".format(
+                    result["status"], result["body"][:200]
+                )
+            )
+        return json.loads(result["body"])
+
+    def _scrape_course_data_from_section_page(self):
+        # Newer echo360 cloud UIs (e.g. echo360.org.uk as of mid-2026) always
+        # serve the React app shell at /section/{id}/syllabus - even an
+        # authenticated in-page fetch() with Accept: application/json gets a
+        # NetworkError, not JSON. There doesn't seem to be an underlying API
+        # worth chasing there anymore, so scrape the rendered section home
+        # page instead: each lesson is a <div class="class-row"
+        # data-test-lessonid="..."> row, and the lesson id itself embeds the
+        # lesson's start/end time (e.g.
+        # "..._2026-07-13T10:00:00.000_2026-07-13T13:00:00.000"), so no
+        # separate date field needs to be parsed out of the row's markup.
+        from selenium.webdriver.common.by import By
+        from selenium.webdriver.support import expected_conditions as EC
+        from selenium.webdriver.support.ui import WebDriverWait
+
+        self.driver.get(self._section_home_url)
+        # the lesson list is rendered client-side by React, so it isn't
+        # present in the page source immediately after navigation.
+        WebDriverWait(self.driver, 20).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, "div.class-row"))
+        )
+        page = self._driver.page_source
+        _LOGGER.debug("Dumping section page at %s: %s", self._section_home_url, page)
+
+        if self._course_name is None:
+            heading_match = self._HEADING_RE.search(page)
+            if heading_match:
+                course_name = re.sub("<[^>]+>", " ", heading_match.group(1))
+                self._course_name = re.sub(r"\s+", " ", course_name).strip()
+
+        lessons = []
+        for class_suffix, lesson_id in self._LESSON_ROW_RE.findall(page):
+            if "live" in class_suffix.split() or "future" in class_suffix.split():
+                # not recorded/available yet, nothing to download
+                continue
+            start_time_match = self._LESSON_START_TIME_RE.search(lesson_id)
+            start_time = start_time_match.group(1) if start_time_match else None
+            lessons.append(
+                {
+                    "lesson": {
+                        "hasVideo": True,
+                        "hasAvailableVideo": True,
+                        "startTimeUTC": start_time,
+                        "lesson": {
+                            "id": lesson_id,
+                            "name": self._course_name or lesson_id,
+                            "createdAt": start_time,
+                        },
+                    }
+                }
+            )
+
+        self.course_data = {"data": lessons}
         return self.course_data

--- a/echo360/course.py
+++ b/echo360/course.py
@@ -2,7 +2,6 @@ import json
 import re
 import sys
 
-import requests
 import selenium
 import logging
 
@@ -200,17 +199,22 @@ class EchoCloudCourse(EchoCourse):
                 self.video_url,
                 self._driver.page_source,
             )
-            # use requests to retrieve data
-            session = requests.Session()
-            # load cookies
-            for cookie in self._driver.get_cookies():
-                session.cookies.set(cookie["name"], cookie["value"])
-
-            r = session.get(self.video_url)
-            if not r.ok:
-                raise Exception("Error: Failed to get m3u8 info for EchoCourse!")
-
-            json_str = r.text
+            # Echo360 now content-negotiates on Accept: a plain browser
+            # navigation to this URL gets the React app shell (HTML), but an
+            # XHR/fetch sent with Accept: application/json from within the
+            # already-authenticated page gets the raw JSON, same as the
+            # React app itself does internally. Replaying the selenium
+            # session's cookies into a fresh requests.Session (as this used
+            # to do) no longer works: Echo360 doesn't recognize that
+            # replayed session and redirects it to the login page instead.
+            fetch_script = """
+                var callback = arguments[arguments.length - 1];
+                fetch(arguments[0], {headers: {'Accept': 'application/json'}, credentials: 'same-origin'})
+                  .then(function(r) { return r.text(); })
+                  .then(function(t) { callback(t); })
+                  .catch(function(e) { callback('FETCH_ERROR: ' + e); });
+            """
+            json_str = self.driver.execute_async_script(fetch_script, self.video_url)
         except ValueError as e:
             raise Exception("Unable to retrieve JSON (course_data) from url", e)
         self.course_data = json.loads(json_str)

--- a/echo360/downloader.py
+++ b/echo360/downloader.py
@@ -111,13 +111,13 @@ def build_firefox_driver(
     log_path,
     persistent_session,
 ):
-    if persistent_session:
+    if persistent_session and not selenium_version_ge_4100:
         raise NotImplementedError(
-            "Save-login not implemented for Firefox! Feel free to make a PR for it..."
+            "Save-login for Firefox requires selenium>=4.10 (it needs the "
+            "modern Options/Service API). Please upgrade selenium, or use "
+            "--chrome instead."
         )
 
-    profile = webdriver.FirefoxProfile()
-    profile.set_preference("general.useragent.override", user_agent)
     kwargs = dict()
 
     if selenium_version_ge_4100:
@@ -125,7 +125,27 @@ def build_firefox_driver(
         from selenium.webdriver.firefox.options import Options
 
         option = Options()
-        option.profile = profile
+
+        if persistent_session:
+            # selenium's FirefoxProfile(profile_directory=...) only *copies*
+            # the given directory into a throwaway temp profile, so it can't
+            # be used to persist login state across runs. Passing "-profile
+            # <dir>" as a raw browser argument instead makes geckodriver
+            # launch Firefox directly against that directory, so
+            # cookies/login state get written back to it and survive across
+            # runs, the same way Chrome's --user-data-dir does above.
+            # (geckodriver rejects setting both a --profile argument and a
+            # FirefoxProfile object, so the user-agent override is set as a
+            # plain preference here instead of via a profile.)
+            folder_path = os.path.abspath(PERSISTENT_SESSION_FOLDER)
+            os.makedirs(folder_path, exist_ok=True)
+            option.add_argument("-profile")
+            option.add_argument(folder_path)
+            option.set_preference("general.useragent.override", user_agent)
+        else:
+            profile = webdriver.FirefoxProfile()
+            profile.set_preference("general.useragent.override", user_agent)
+            option.profile = profile
 
         service = Service(**kwargs, log_file=log_path)
         kwargs = dict(
@@ -133,6 +153,10 @@ def build_firefox_driver(
             options=option,
         )
     else:
+        # persistent_session is guaranteed False here (checked above).
+        profile = webdriver.FirefoxProfile()
+        profile.set_preference("general.useragent.override", user_agent)
+
         if use_local_binary:
             from .binary_downloader.firefoxdriver import FirefoxDownloader
 

--- a/echo360/downloader.py
+++ b/echo360/downloader.py
@@ -369,11 +369,10 @@ class EchoDownloader(object):
         videos = self._course.get_videos().videos
         print("Done!")
         # change the output directory to be inside a folder named after the course
-        self._output_dir = os.path.join(
-            self._output_dir, "{0}".format(self._course.nice_name).strip()
+        course_folder_name = self.regex_replace_invalid.sub(
+            "_", "{0}".format(self._course.nice_name).strip()
         )
-        # replace invalid character for folder
-        self.regex_replace_invalid.sub("_", self._output_dir)
+        self._output_dir = os.path.join(self._output_dir, course_folder_name)
 
         filtered_videos = [video for video in videos if self._in_date_range(video.date)]
         videos_to_be_download = []


### PR DESCRIPTION
## Summary
- Echo360's cloud UI (as of mid-2026) no longer returns JSON from `/section/{id}/syllabus` for course/lesson listing - it always serves the React app shell instead, even for an authenticated in-page `fetch()` with `Accept: application/json`. `EchoCloudCourse` now tries the JSON endpoint first (kept for any instance where it still works) and falls back to scraping the rendered section home page's `data-test-lessonid` rows when it doesn't.
- Implemented `--persistent-session` for the Firefox driver, which previously just raised `NotImplementedError` and forced a fresh SSO login on every single run.
- Fixed a pre-existing bug where output-folder character sanitization was computed and discarded rather than applied, letting a `/` in a scraped course name silently create extra nested directories.

## Test plan
- [x] Verified end-to-end against a real `echo360.org.uk` section: course info retrieval (10/10 lessons found), per-lesson m3u8 discovery, both video feeds downloading, and audio/video muxing to mp4 all completed successfully.
- [x] Verified Firefox `--persistent-session` launches without the previous `NotImplementedError` and correctly reuses a saved profile directory across runs.
- [x] Verified the output-directory fix produces a single sanitized folder instead of nested directories from an unsanitized `/` in the course name.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Echo360 course listing by trying the JSON syllabus API first and scraping the section page when JSON isn’t available. Adds Firefox persistent sessions and fixes output folder naming to avoid accidental nested directories.

- **New Features**
  - Echo360: Attempts JSON at `/section/{id}/syllabus` via in-page fetch; if unavailable, scrapes `/section/{id}/home` for `data-test-lessonid` rows to build the lesson list.
  - Firefox: Adds `--persistent-session` by launching with `-profile <dir>` so logins persist across runs. Requires `selenium` >= 4.10; older versions raise with guidance.

- **Bug Fixes**
  - Properly sanitizes the course folder name before joining the path, preventing nested directories from characters like `/`.

<sup>Written for commit 04be03c26acf33abe9fad4adefaee5be7522f08a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/soraxas/echo360/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

